### PR TITLE
feat: improve table page with individual sensor data display

### DIFF
--- a/frontend/hooks/useApiOptimized.ts
+++ b/frontend/hooks/useApiOptimized.ts
@@ -214,7 +214,7 @@ export const useSensorData = (
     setLoading(true);
     try {
       setError(null);
-      const result = await fetchApi<{items: SensorData[], total: number, page: number, size: number, pages: number}>(`/sensors/?page=${pageNum}&limit=${limitNum}`, abortSignal);
+      const result = await fetchApi<{items: SensorData[], total: number, page: number, size: number, pages: number}>(`/sensors/?page=${pageNum}&size=${limitNum}`, abortSignal);
       if (!abortSignal?.aborted) {
         setData(result.items);
         setPagination({


### PR DESCRIPTION
- Remove complex grouping logic for simpler individual sensor display
- Fix API endpoint from /api/sensors/ to /sensors/ (base URL already includes /api)
- Update table structure to show: Device, Timestamp, Sensor Type, Value, Unit, Status
- Use API pagination directly instead of client-side pagination
- Fix statistics to show total records from API response
- Update export CSV for individual sensor data format
- Improve error handling and loading states